### PR TITLE
Adding ddgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@
 #### Supportive Tool
 - [![Open-Source Software][OSS Icon]](https://github.com/jarun/Buku) [Buku](https://github.com/jarun/Buku) - Command line bookmark manager.
 - [Clipgrab](https://clipgrab.org/) - A friendly downloader for YouTube and other sites.
+- [![Open-Source Software][OSS Icon]](https://github.com/jarun/ddgr) [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the command line.
 - [![Open-Source Software][OSS Icon]](https://github.com/jarun/googler) [googler](https://github.com/jarun/googler) - Google any stuff right in the command line.
 - [Tor](https://www.torproject.org/) - Tor is free software and an open network that helps you defend against traffic analysis, a form of network surveillance that threatens personal freedom and privacy.
 - [![Open-Source Software][OSS Icon]](https://github.com/rg3/youtube-dl) [youtube-dl](https://github.com/rg3/youtube-dl) - Command line video downloader from youtube.com and about other thousand video platforms. It's really awesome, at least for me.


### PR DESCRIPTION
`ddgr` is a Python3 utility to search DuckDuckGo from the terminal.

Features:

- Fast and clean (no ads, stray URLs or clutter), custom color                                                                                 
- Designed to deliver maximum readability at minimum space                                                                                     
- Specify the number of search results to show per page                                                                                        
- Navigate result pages from omniprompt, open URLs in browser                                                                                  
- Search and option completion scripts for Bash, Zsh and Fish                                                                                  
- DuckDuckGo Bang support (along with completion)                                                                                              
- Open the first result directly in browser (as in I'm Feeling Ducky)                                                                          
- Non-stop searches: fire new searches at omniprompt without exiting                                                                           
- Keywords (e.g. `filetype:mime`, `site:somesite.com`) support                                                                                 
- Limit search by time, specify region, disable safe search                                                                                    
- HTTPS proxy support, Do Not Track set, optionally disable User Agent                                                                         
- Support custom url handler script or cmdline utility                                                                                         
- Comprehensive documentation, man page with handy usage examples                                                                              
- Minimal dependencies