### PR TITLE
Adds Gifcurry

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@
 - [![Open-Source Software][OSS Icon]](https://github.com/aseprite/aseprite/) [Aseprite](https://www.aseprite.org/) - Animated sprite editor & pixel art tool.
 - [![Open-Source Software][OSS Icon]](http://archive.blender.org/download/source-code/index.html) [Blender](https://www.blender.org/) - a free and open source complete 3D creation pipeline for artists and small teams.
 - [![Open-Source Software][OSS Icon]](https://sourceforge.net/projects/cinepaint/) [Cinepaint](http://www.cinepaint.org/) - Open source deep paint software.
+- [![Open-Source Software][OSS Icon]](https://github.com/lettier/gifcurry) [Gifcurry](https://lettier.github.io/gifcurry/) - Your open source video to GIF maker built with Haskell.
 - [Gravit](https://www.designer.io/) - Gravit Designer is a full featured free vector design app right at your fingertip.
 - [Heron Animation](https://www.heronanimation.brick-a-brack.com/#download) - A free stop animation making program.
 - [![Open-Source Software][OSS Icon]](https://github.com/inkscape/inkscape) [Inkscape](https://inkscape.org/en/) - A powerful, free design tool for you , whether you are an illustrator, designer, web designer or just someone who needs to create some vector imagery.


### PR DESCRIPTION
Hello,

![Gifcurry](https://user-images.githubusercontent.com/1661343/38966588-ff81782e-4350-11e8-87d5-ee991c339324.png)


This adds [Gifcurry](https://lettier.github.io/gifcurry) ([source](https://github.com/lettier/gifcurry)) to the list.

#### Linux Distribution

- [Snap](https://snapcraft.io/gifcurry)
- Flathub (Flatpak) (coming soon)
- [AppImage](https://appimage.github.io/gifcurry/)
- [Arch](https://aur.archlinux.org/packages/gifcurry/)

#### In the Media

- [OMG! Ubuntu! ](https://www.omgubuntu.co.uk/2017/09/create-gif-from-video-linux-app)
- [eTechRoom](https://etechroom.com/create-gif-from-video/)
- [TECHFOUR](https://www.youtube.com/watch?v=DLOXkkKZG_0)
- [ZenWay](http://zenway.ru/page/gifcurry)

:+1: 