### PR TITLE
Gaming Applications/Tools: Add WineZGUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/CapitaineJSparrow/steam-repo-manager) [Steam Deck Repo Manager](https://steamdeckrepo.com/) - Install boot videos to your Steam Deck using Steam Deck Repo website API.
 - [![Open-Source Software][oss icon]](https://github.com/SteamGridDB/steam-rom-manager) [Steam ROM Manager](https://steamgriddb.github.io/steam-rom-manager/) - An app for managing ROMs in Steam.
 - [![Open-Source Software][oss icon]](https://github.com/sonic2kk/steamtinkerlaunch) [SteamTinkerLaunch](https://github.com/sonic2kk/steamtinkerlaunch) - Linux wrapper tool for use with the Steam client for custom launch options and 3rd party programs.
+- [![Open-Source Software][oss icon]](https://github.com/fastrizwaan/WineZGUI/) [WineZGUI](https://github.com/fastrizwaan/WineZGUI/) - GUI Frontend using Zenity for running Windows games with Wine that allows you to create, manage, and share game prefixes.
 
 ##### W.I.N.E.
 


### PR DESCRIPTION
Adds [WineZGUI](https://github.com/fastrizwaan/WineZGUI/); a GUI Frontend for launching and managing Windows games (or other executables) including prefix management. It also allows you to share preconfigured prefixes for specific Wine versions, and features Desktop Integration to launch executables with WineZGUI automatically.

WineZGUI is FOSS ([available on GitHub](https://github.com/fastrizwaan/WineZGUI/), licensed under the terms of the GNU GPL-3.0 license.