### PR TITLE
Removed link https://www.ubuntugeek.com/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1808,7 +1808,6 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [Repology](https://repology.org/)
 - [Slashdot](https://linux.slashdot.org/)
 - [TecMint](https://www.tecmint.com/)
-- [Ubuntu Geek](https://www.ubuntugeek.com/)
 - [UbuntuHandbook](https://ubuntuhandbook.org/)
 - [Unixmen](https://www.unixmen.com/)
 - [Webupd8](http://www.webupd8.org/)

--- a/Readme_ar-AR.md
+++ b/Readme_ar-AR.md
@@ -1799,7 +1799,6 @@
 - [ريبولوجي](https://repology.org/)
 - [سلاش دوت](https://linux.slashdot.org/)
 - [تكمنت](https://www.tecmint.com/)
-- [أوبونتو جيك](https://www.ubuntugeek.com/)
 - [UbuntuHandbook](https://ubuntuhandbook.org/)
 - [يونيكسمن](https://www.unixmen.com/)
 - [تحديث الويب](http://www.webupd8.org/)


### PR DESCRIPTION
https://www.ubuntugeek.com/ is not reachable anymore and had no activity in 2024; Removed it

## Summary by Sourcery

Documentation:
- Remove the link to www.ubuntugeek.com, which is no longer reachable.