### PR TITLE
Add Wallhaven project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,6 +1634,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 ### Internet
 
 - [![Open-Source Software][oss icon]](https://github.com/federicotorrielli/Daily-Reddit-Wallpaper) [Daily Reddit Wallpaper](https://federicotorrielli.github.io/Daily-Reddit-Wallpaper/) - Change your wallpaper to the most upvoted image of the day from /r/wallpapers or any other subreddit on system startup.
+- [![Open-Source Software][oss icon]](https://github.com/federicotorrielli/wallhaven) [Wallhaven](https://github.com/federicotorrielli/wallhaven) - A KISS suckless-style script for downloading and setting wallpapers from Wallhaven using their API.
 - [![Open-Source Software][oss icon]](https://github.com/jarun/ddgr) [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the command line.
 - [![Open-Source Software][oss icon]](https://dnscrypt.info/) [dnscrypt-proxy](https://github.com/DNSCrypt/dnscrypt-proxy) - DNS proxy with support for encrypted DNS protocols,cross platform.
 - [![Open-Source Software][oss icon]](https://github.com/mikf/gallery-dl) [gallery-dl](https://github.com/mikf/gallery-dl) - Command-line program to download image galleries and collections from pixiv, exhentai, danbooru and more.


### PR DESCRIPTION
Adding Wallhaven script to the repo.  Wallhaven is desktop changer and wallhaven downloader for Linux, KISS style. 

## Motivation and Context
None.

## How Has This Been Tested?
Tested on CachyOS, rolling. Gnome.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Summary by Sourcery

Documentation:
- Include Wallhaven script with description and GitHub link in the README's list of internet tools