### PR TITLE
Remove foss icon from aseprite(fix #867)

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 #### Graphic Creation
 
-- ![Nonfree][money icon][![Open-Source Software][oss icon]](https://github.com/aseprite/aseprite/) [Aseprite](https://www.aseprite.org/) - Animated sprite editor & pixel art tool.
+- ![Nonfree][money icon][Aseprite](https://www.aseprite.org/) - Animated sprite editor & pixel art tool.
 - [![Open-Source Software][oss icon]](https://download.blender.org/source/) [Blender](https://www.blender.org/) - A free and open source complete 3D creation pipeline for artists and small teams.
 - [![Open-Source Software][oss icon]](https://sourceforge.net/projects/cinepaint/) [Cinepaint](http://cinepaint.org/) - Open source deep paint software.
 - [![Open-Source Software][oss icon]](https://github.com/maoschanz/drawing) [Drawing](https://maoschanz.github.io/drawing/) - This free basic raster image editor is similar to Microsoft Paint, but aiming at the GNOME desktop.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
I removed the foss icon and Github link as Aseprite is no longer free or open-source software
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Aseprite has moved away from the GPL and now uses a EULA t**hat does not allow redistribution** thus making it no longer free and open-source.
https://dev.aseprite.org/2016/09/01/new-source-code-license/
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

## Summary by Sourcery

Update software listing to reflect Aseprite’s current licensing status as non-free, removing its open‑source indicator and source link.

Bug Fixes:
- Correct the Aseprite listing to no longer present it as free/open‑source software now that it uses a non‑redistributable license.

Documentation:
- Adjust README graphic creation section to remove the open‑source icon and GitHub source link from the Aseprite entry.