### PR TITLE
Add NullSec Linux to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1257,6 +1257,8 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 #### Network Analysis
 
+- [![Open-Source Software][oss icon]](https://github.com/bad-antics/nullsec-linux) [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security-focused Linux distribution with 135+ pre-installed penetration testing, forensics, and network analysis tools. Based on Debian 13 with 9 specialized editions.
+
 - [![Open-Source Software][oss icon]](https://www.tcpdump.org/#source) [Tcpdump](https://www.tcpdump.org/) - TCP Debugging/Capture Tool.
 - [![Open-Source Software][oss icon]](https://github.com/gcla/termshark) [Termshark](https://termshark.io/) - A terminal UI for tshark, inspired by Wireshark.
 - [![Open-Source Software][oss icon]](https://gitlab.com/wireshark/wireshark/-/tree/master) [Wireshark](https://www.wireshark.org/) - Wireshark is the world's foremost network protocol analyzer. It lets you see what's happening on your network at a microscopic level. It is the de facto (and often de jure) standard across many industries and educational institutions.

--- a/README.md
+++ b/README.md
@@ -1257,7 +1257,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 #### Network Analysis
 
-- [![Open-Source Software][oss icon]](https://github.com/bad-antics/nullsec-linux) [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security-focused Linux distribution with 135+ pre-installed penetration testing, forensics, and network analysis tools. Based on Debian 13 with 9 specialized editions.
+- [![Open-Source Software][oss icon]](https://github.com/bad-antics/nullsec-linux) [NullSec Linux](https://bad-antics.github.io) - Security-focused distro with 135+ tools for penetration testing and forensics.
 
 - [![Open-Source Software][oss icon]](https://www.tcpdump.org/#source) [Tcpdump](https://www.tcpdump.org/) - TCP Debugging/Capture Tool.
 - [![Open-Source Software][oss icon]](https://github.com/gcla/termshark) [Termshark](https://termshark.io/) - A terminal UI for tshark, inspired by Wireshark.


### PR DESCRIPTION
## Summary
Add NullSec Linux to the Security > Network Analysis section.

## Distribution Details
**NullSec Linux** - Security-focused Linux Distribution

- **Repository**: https://github.com/bad-antics/nullsec-linux
- **Website**: https://bad-antics.github.io
- **Base**: Debian 13 (Trixie)
- **License**: GPL-3.0

## Features
- 🔧 135+ pre-installed security tools
- 🎯 9 specialized editions
- 🦀 Custom tools in Rust, Go, Zig, Python
- 📦 Network analysis and packet capture tools
- 🔍 Forensics and incident response capabilities

Actively maintained with regular updates. Looking for contributors!

## Summary by Sourcery

Documentation:
- Document NullSec Linux in the Security > Network Analysis section, highlighting its focus, toolset, and Debian 13 base.