### PR TITLE
Add NullSec Tools to Security Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,6 +1291,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/radareorg/radare2/releases) [radare2](https://rada.re/n/radare2.html) - A free/libre toolchain for easing several low level tasks like forensics, software reverse engineering, exploiting, debugging.
 
 #### Other
+- [![Open-Source Software][oss icon]](https://github.com/bad-antics/nullsec-tools) [NullSec Tools](https://github.com/bad-antics/nullsec-tools) - Professional security toolkit with Python, Go, Rust, C tools for pentesting, OSINT, hash cracking, and more.
 
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/Authenticator) [Authenticator](https://apps.gnome.org/app/com.belmoussaoui.Authenticator/) - Simple application for generating Two-Factor Authentication Codes.
 - [![Open-Source Software][oss icon]](https://github.com/Cisco-Talos/clamav-devel) [ClamAV](https://www.clamav.net/) - ClamAV is an open source antivirus engine for detecting trojans, viruses, malware & other malicious threats.

--- a/README.md
+++ b/README.md
@@ -1291,7 +1291,6 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/radareorg/radare2/releases) [radare2](https://rada.re/n/radare2.html) - A free/libre toolchain for easing several low level tasks like forensics, software reverse engineering, exploiting, debugging.
 
 #### Other
-- [![Open-Source Software][oss icon]](https://github.com/bad-antics/nullsec-tools) [NullSec Tools](https://github.com/bad-antics/nullsec-tools) - Professional security toolkit with Python, Go, Rust, C tools for pentesting, OSINT, hash cracking, and more.
 
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/Authenticator) [Authenticator](https://apps.gnome.org/app/com.belmoussaoui.Authenticator/) - Simple application for generating Two-Factor Authentication Codes.
 - [![Open-Source Software][oss icon]](https://github.com/Cisco-Talos/clamav-devel) [ClamAV](https://www.clamav.net/) - ClamAV is an open source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
@@ -1303,6 +1302,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/firehol/iprange) [IPrange](https://github.com/firehol/iprange) - A very fast command line utility for processing IP lists (merge, compare, exclude, etc).
 - [![Open-Source Software][oss icon]](https://github.com/jarun/spy) [spy](https://github.com/jarun/spy) - Linux kernel mode debugfs keylogger.
 - [![Open-Source Software][oss icon]](https://github.com/CISOfy/lynis) [Lynis](https://cisofy.com/lynis/) - Security auditing tool for Linux, macOS, and UNIX-based systems. Assists with compliance testing (HIPAA/ISO27001/PCI DSS) and system hardening. Agentless, and installation optional.
+- [![Open-Source Software][oss icon]](https://github.com/bad-antics/nullsec-tools) [NullSec Tools](https://github.com/bad-antics/nullsec-tools) - Multi-language security toolkit for pentesting and OSINT.
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/obfuscate/) [Obfuscate](https://apps.gnome.org/app/com.belmoussaoui.Obfuscate/) - Obfuscate lets you redact your private information from any image.
 - [![Open-Source Software][oss icon]](https://www.openbsd.org/anoncvs.html) [OpenSSH](https://www.openssh.com/) - OpenSSH Secure Shell Server and Client.
 - [![Open-Source Software][oss icon]](https://github.com/zaproxy/zaproxy/) [OWASP ZAP](https://www.zaproxy.org) - OWASP Zed Attack Proxy (ZAP) web security testing tool.


### PR DESCRIPTION
## Description
Adding NullSec Tools to the Security > Other section.

**NullSec Tools** is a professional security toolkit including:
- Python, Go, Rust, C security tools
- Pentesting utilities
- OSINT tools
- Hash cracking
- Network analysis
- And more...

All tools are open source and part of the NullSec security framework.

Repository: https://github.com/bad-antics/nullsec-tools

## Summary by Sourcery

Documentation:
- Document the NullSec Tools open-source security toolkit in the Security > Other section of the README.