### PR TITLE
Add DevToolbox Cheats (productivity tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/costales/anoise) [Ambient Noise](https://github.com/costales/anoise) - An ambient noise generator for Linux.
 - [![Open-Source Software][oss icon]](https://github.com/jarun/bcal) [bcal](https://github.com/jarun/bcal) - Perform storage conversions and calculations.
 - [![Open-Source Software][oss icon]](https://github.com/hluk/CopyQ) [CopyQ](https://hluk.github.io/CopyQ/) -CopyQ is advanced clipboard manager with editing and scripting features.
+- [DevToolbox Cheats](https://github.com/dominatos/devtoolbox-cheats) - Universal Linux cheatsheet manager with native KDE Plasma 5/6 widgets, GNOME Argos integration, and 100+ production sysadmin cheatsheets.
 - [f.lux](https://justgetflux.com/linux.html) - A program that reddens your display to help you sleep better.
 - [![Open-Source Software][oss icon]](https://github.com/thezbyg/gpick) [Gpick](https://www.gpick.org/) - Gpick allows you to sample any color from anywhere on your desktop, and it also provides some other advanced features!
 - [![Open-Source Software][oss icon]](https://github.com/jarun/pdd) [pdd](https://github.com/jarun/pdd) - Tiny date, time diff calculator.


### PR DESCRIPTION
## What does it do?

Universal cross-desktop Linux cheatsheet manager for sysadmins/DevOps with:

- Native **KDE Plasma 5/6 widgets**
- **GNOME Argos** panel integration
- Dialog menus for **15+ desktop environments**
- **133 production-ready cheatsheets** (Docker, K8s, networking, databases)


## Why it belongs here

- Real productivity tool for Linux sysadmins
- Cross-desktop compatibility
- Batteries included


## Links

- Repo: https://github.com/dominatos/devtoolbox-cheats
- Screenshots: https://github.com/dominatos/devtoolbox-cheats#example-screenshots
- Release: https://github.com/dominatos/devtoolbox-cheats/releases
- MIT License

## Summary by Sourcery

Documentation:
- Document DevToolbox Cheats as a recommended productivity tool, highlighting its cross-desktop integration and bundled sysadmin cheatsheets.