### PR TITLE
Add dictee — offline voice dictation with KDE Plasma 6 plasmoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/needle-and-thread/vocal) [Vocal](https://vocalproject.net/) - Podcast client for the modern desktop.
 
 #### Utilities
+- [![Open-Source Software][oss icon]](https://github.com/rcspam/dictee) [dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation for Linux. 100% local, multilingual (25+ languages), with speaker diarization. GTK3/Bash frontend, Rust/ONNX backend.
 
 - [![Open-Source Software][oss icon]](https://github.com/karlstav/cava) [cava](https://github.com/karlstav/cava) - Cava is a Cross-platform Audio Visualizer.
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/eartag) [Ear Tag](https://apps.gnome.org/EarTag/) - Small and simple audio file tag editor.

--- a/README.md
+++ b/README.md
@@ -244,9 +244,8 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/needle-and-thread/vocal) [Vocal](https://vocalproject.net/) - Podcast client for the modern desktop.
 
 #### Utilities
-- [![Open-Source Software][oss icon]](https://github.com/rcspam/dictee) [dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation for Linux. 100% local, multilingual (25+ languages), with speaker diarization. GTK3/Bash frontend, Rust/ONNX backend.
-
 - [![Open-Source Software][oss icon]](https://github.com/karlstav/cava) [cava](https://github.com/karlstav/cava) - Cava is a Cross-platform Audio Visualizer.
+- [![Open-Source Software][oss icon]](https://github.com/rcspam/dictee) [dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation for Linux with KDE Plasma 6 plasmoid, 4 offline ASR backends, post-processing and translation. 100% local, 25+ languages.
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/eartag) [Ear Tag](https://apps.gnome.org/EarTag/) - Small and simple audio file tag editor.
 - [![Open-Source Software][oss icon]](https://github.com/GNOME/easytag) [EasyTag](https://github.com/GNOME/easytag) - Edit audio file metadata.
 - [![Open-Source Software][oss icon]](https://github.com/enzo1982/freac) [fre:ac](https://www.freac.org) - fre:ac is a free audio converter and CD ripper with support for various popular formats and encoders. It currently converts between MP3, MP4/M4A, WMA, Ogg Vorbis, FLAC, AAC, WAV and Bonk formats.


### PR DESCRIPTION
## What is dictee?

[dictee](https://github.com/rcspam/dictee) is a push-to-talk voice dictation tool for Linux. It supports 4 offline ASR backends (Parakeet-TDT, Canary-1B, Vosk, faster-Whisper), a KDE Plasma 6 plasmoid widget, post-processing rules, and optional translation. Everything runs 100% locally with support for 25+ languages.

- KDE Plasma 6 plasmoid with animated audio visualizer
- 4 offline ASR backends: NVIDIA Parakeet-TDT 0.6B, Canary-1B, Vosk, faster-Whisper
- Post-processing: punctuation rules, dictionaries, LLM correction
- Optional translation (translate-shell, LibreTranslate, Ollama)
- systray (PyQt6) for non-KDE desktops
- Packages: .deb (Ubuntu/Debian), .rpm (Fedora/openSUSE), PKGBUILD (Arch)

Added to **Audio > Utilities** section, alphabetically after cava.