### PR TITLE
Add Inkwell to Markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 #### Markdown
 
 - [![Open-Source Software][oss icon]](https://github.com/wereturtle/ghostwriter) [Ghost Writer](https://ghostwriter.kde.org/) - A distraction-free Markdown editor for Windows and Linux.
-- [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, focus mode, and diff viewer. Built with Tauri v2.
+- [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Lightweight Markdown editor for Linux, Windows, and macOS with split view, live preview, themes, focus mode, and diff viewer.
 - [![Open-Source Software][oss icon]](https://github.com/fabiocolacio/Marker) [Marker](https://github.com/fabiocolacio/Marker) - Marker is a markdown editor for linux made with GTK+-3.0.
 - [![Open-Source Software][oss icon]](https://github.com/marktext/marktext) [MarkText](https://github.com/marktext/marktext) - MarkText is a free and open-source realtime preview markdown editor which support both CommonMark Spec and GitHub Flavored Markdown Spec. It is a concise text editor, dedicated to improving your writing efficiency.
 - [![Open-Source Software][oss icon]](https://github.com/jamiemcg/remarkable) [Remarkable](https://remarkableapp.github.io/) - A capable markdown editor that uses a variant of GitHub Flavored Markdown (GFM).

--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 #### Markdown
 
 - [![Open-Source Software][oss icon]](https://github.com/wereturtle/ghostwriter) [Ghost Writer](https://ghostwriter.kde.org/) - A distraction-free Markdown editor for Windows and Linux.
+- [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, focus mode, and diff viewer. Built with Tauri v2.
 - [![Open-Source Software][oss icon]](https://github.com/fabiocolacio/Marker) [Marker](https://github.com/fabiocolacio/Marker) - Marker is a markdown editor for linux made with GTK+-3.0.
 - [![Open-Source Software][oss icon]](https://github.com/marktext/marktext) [MarkText](https://github.com/marktext/marktext) - MarkText is a free and open-source realtime preview markdown editor which support both CommonMark Spec and GitHub Flavored Markdown Spec. It is a concise text editor, dedicated to improving your writing efficiency.
 - [![Open-Source Software][oss icon]](https://github.com/jamiemcg/remarkable) [Remarkable](https://remarkableapp.github.io/) - A capable markdown editor that uses a variant of GitHub Flavored Markdown (GFM).

--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 #### Markdown
 
 - [![Open-Source Software][oss icon]](https://github.com/wereturtle/ghostwriter) [Ghost Writer](https://ghostwriter.kde.org/) - A distraction-free Markdown editor for Windows and Linux.
-- [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Lightweight Markdown editor for Linux, Windows, and macOS with split view, live preview, themes, focus mode, and diff viewer.
+- [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Lightweight Markdown editor with split view, live preview, 4 themes, Mermaid diagrams, and LaTeX math. No cloud, no telemetry. [![Nonfree][Money Icon]
 - [![Open-Source Software][oss icon]](https://github.com/fabiocolacio/Marker) [Marker](https://github.com/fabiocolacio/Marker) - Marker is a markdown editor for linux made with GTK+-3.0.
 - [![Open-Source Software][oss icon]](https://github.com/marktext/marktext) [MarkText](https://github.com/marktext/marktext) - MarkText is a free and open-source realtime preview markdown editor which support both CommonMark Spec and GitHub Flavored Markdown Spec. It is a concise text editor, dedicated to improving your writing efficiency.
 - [![Open-Source Software][oss icon]](https://github.com/jamiemcg/remarkable) [Remarkable](https://remarkableapp.github.io/) - A capable markdown editor that uses a variant of GitHub Flavored Markdown (GFM).


### PR DESCRIPTION
Adds [Inkwell](https://github.com/4worlds4w-svg/inkwell) to the Office > Markdown section.

- Portable Markdown editor built with Rust + Tauri v2
- Split view, live preview, themes, focus mode, typewriter mode, find & replace, diff viewer
- Single executable, no install required (~8.5 MB on Linux)
- Free to use; PDF/HTML export requires a one-time Pro license

## Summary by Sourcery

Documentation:
- Document Inkwell as an additional Markdown editor option with a brief feature description in the README.