### PR TITLE
Add onWatch to System Info / Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1663,7 +1663,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/sharkdp/hyperfine) [hyperfine](https://github.com/sharkdp/hyperfine) - A command-line benchmarking tool.
 - [![Open-Source Software][oss icon]](https://github.com/orhun/kmon) [kmon](https://kmon.cli.rs/) - Linux Kernel Manager and Activity Monitor.
 - [![Open-Source Software][oss icon]](https://github.com/Syllo/nvtop) [NVTOP](https://github.com/Syllo/nvtop) - GPUs process monitoring for AMD, Intel and NVIDIA.
-- [![Open-Source Software][oss icon]](https://github.com/onllm-dev/onwatch) [onWatch](https://github.com/onllm-dev/onwatch) - CLI tool that monitors AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, and more) with a web dashboard. Background daemon, <50MB RAM, zero telemetry.
+- [![Open-Source Software][oss icon]](https://github.com/onllm-dev/onwatch) [onWatch](https://github.com/onllm-dev/onwatch) - Monitor AI API quota usage across multiple providers with a web dashboard.
 - [![Open-Source Software][oss icon]](https://github.com/dylanaraps/pfetch) [pfetch](https://github.com/dylanaraps/pfetch) - A pretty system information tool written in POSIX sh.
 - [![Open-Source Software][oss icon]](https://github.com/KittyKatt/screenFetch) [screenFetch](https://github.com/KittyKatt/screenFetch) - Fetches system/theme information in terminal for Linux desktop screenshots.
 - [![Open-Source Software][oss icon]](https://github.com/amanusk/s-tui) [s-tui](https://amanusk.github.io/s-tui/) - s-tui is an UI for monitoring your computer's CPU temperature, frequency and utilization in a graphical way from the terminal.

--- a/README.md
+++ b/README.md
@@ -1663,6 +1663,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/sharkdp/hyperfine) [hyperfine](https://github.com/sharkdp/hyperfine) - A command-line benchmarking tool.
 - [![Open-Source Software][oss icon]](https://github.com/orhun/kmon) [kmon](https://kmon.cli.rs/) - Linux Kernel Manager and Activity Monitor.
 - [![Open-Source Software][oss icon]](https://github.com/Syllo/nvtop) [NVTOP](https://github.com/Syllo/nvtop) - GPUs process monitoring for AMD, Intel and NVIDIA.
+- [![Open-Source Software][oss icon]](https://github.com/onllm-dev/onwatch) [onWatch](https://github.com/onllm-dev/onwatch) - CLI tool that monitors AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, and more) with a web dashboard. Background daemon, <50MB RAM, zero telemetry.
 - [![Open-Source Software][oss icon]](https://github.com/dylanaraps/pfetch) [pfetch](https://github.com/dylanaraps/pfetch) - A pretty system information tool written in POSIX sh.
 - [![Open-Source Software][oss icon]](https://github.com/KittyKatt/screenFetch) [screenFetch](https://github.com/KittyKatt/screenFetch) - Fetches system/theme information in terminal for Linux desktop screenshots.
 - [![Open-Source Software][oss icon]](https://github.com/amanusk/s-tui) [s-tui](https://amanusk.github.io/s-tui/) - s-tui is an UI for monitoring your computer's CPU temperature, frequency and utilization in a graphical way from the terminal.


### PR DESCRIPTION
## Summary

- Adds [onWatch](https://github.com/onllm-dev/onwatch) to the **Command Line Utilities > System Info / Monitoring** section
- Placed alphabetically between NVTOP and pfetch

## About onWatch

onWatch is an open-source Go CLI that monitors AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, Synthetic, Z.ai, MiniMax, and Antigravity). It runs as a lightweight background daemon (<50MB RAM, ~15MB binary) with zero telemetry and includes a Material Design 3 web dashboard.

- **License:** GPL-3.0
- **Stars:** 342+
- **Platform:** Linux (amd64, arm64), macOS, Windows
- **Install:** One-line curl install, Homebrew, or Docker

## Summary by Sourcery

Documentation:
- Document onWatch as a system monitoring CLI that tracks AI API quota usage with a web dashboard in the System Info / Monitoring section of the README.