### PR TITLE
Add Vector Privacy to Chat Full Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [Slack](https://slack.com/downloads/linux) - Real-time messaging, archiving and search for modern teams.
 - [![Open-Source Software][oss icon]](https://github.com/telegramdesktop/tdesktop) [Telegram](https://desktop.telegram.org/) - A messaging app with a focus on speed and security, it’s super fast, simple and free.
 - [![Open-Source Software][oss icon]](https://github.com/linagora/Twake) [Twake](https://twake.app/) - Open-source alternative to Microsoft Teams.
+- [Vector](https://vectorapp.io) - No KYC, E2EE, Decentralized, Censorship-Resistant, No Metadata. Free, Open-Source.
 - [Viber](https://www.viber.com/download/) - Viber for Linux lets you send free messages and make free calls to other Viber users on any device and network, in any country.
 - [![Open-Source Software][oss icon]](https://github.com/wireapp) [Wire](https://wire.com/en/) - Secure communication. Full privacy.
 - [![Open-Source Software][oss icon]](https://github.com/zulip/zulip) [Zulip](https://zulip.com/) - Zulip is a powerful, open source group chat application that combines the immediacy of real-time chat with the productivity benefits of threaded conversations.

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [Slack](https://slack.com/downloads/linux) - Real-time messaging, archiving and search for modern teams.
 - [![Open-Source Software][oss icon]](https://github.com/telegramdesktop/tdesktop) [Telegram](https://desktop.telegram.org/) - A messaging app with a focus on speed and security, it’s super fast, simple and free.
 - [![Open-Source Software][oss icon]](https://github.com/linagora/Twake) [Twake](https://twake.app/) - Open-source alternative to Microsoft Teams.
-- [Vector](https://vectorapp.io) - No KYC, E2EE, Decentralized, Censorship-Resistant, No Metadata. Free, Open-Source.
+- [![Open-Source Software][oss icon]](https://github.com/vectorprivacy/vector)[Vector](https://vectorapp.io) - No KYC, E2EE, Decentralized, Censorship-Resistant, No Metadata.
 - [Viber](https://www.viber.com/download/) - Viber for Linux lets you send free messages and make free calls to other Viber users on any device and network, in any country.
 - [![Open-Source Software][oss icon]](https://github.com/wireapp) [Wire](https://wire.com/en/) - Secure communication. Full privacy.
 - [![Open-Source Software][oss icon]](https://github.com/zulip/zulip) [Zulip](https://zulip.com/) - Zulip is a powerful, open source group chat application that combines the immediacy of real-time chat with the productivity benefits of threaded conversations.


### PR DESCRIPTION
Added a new entry for Vector Privacy under Chat.

- Free, Open-Source
- No KYC
- End-to-end Encryption (Private + Group Chats)
- Decentralized (Nostr Relay Network)
- Censorship-Resistant
- No Metadata Tracking
- No Ads

Additional Info:

vectorapp.io
docs.vectorapp.io
github.com/vectorprivacy

## Motivation and Context
This is needed because it solves the issue of privacy and censorship-resistance with chat communications. You own our account and your data in decentralized fashion. There is no thought police than can control it or ban your account.

## How Has This Been Tested?
Been tested across many Linux distros and works as intended. Still some bugs though as it's in Open Beta, but fully functional and baseline works as intended.

## Summary by Sourcery

Documentation:
- Document Vector as a new privacy-focused, open-source chat client option in the Chat section of the README.