### PR TITLE
Add gitty — minimal Git+GitHub CLI tool to Git section

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/Murmele/Gittyup) [Gittyup](https://murmele.github.io/Gittyup/) - Gittyup is a graphical Git client designed to help you understand and manage your source code history.
 - [![Open-Source Software][oss icon]](https://github.com/gogs/gogs) [Gogs](https://gogs.io/) - A painless self-hosted Git service.
 - [![Open-Source Software][oss icon]](https://github.com/jesseduffield/lazygit) [lazygit](https://github.com/jesseduffield/lazygit) - A simple terminal UI for git commands, written in Go with the gocui library.
+- [![Open-Source Software][oss icon]](https://github.com/Omibranch/gitty) [gitty](https://github.com/Omibranch/gitty) - Single-binary CLI tool that replaces git add/commit/push workflows with human-readable commands. Written in Go.
 - ![Nonfree][money icon] [SmartGit](https://www.syntevo.com/smartgit/) - SmartGit is a Git client with support for GitHub Pull Requests+Comments and SVN.
 - [![Open-Source Software][oss icon]](https://github.com/sourcegit-scm/sourcegit) [SourceGit](https://sourcegit-scm.github.io/) - SourceGit is a simple graphical git client available for Windows, macOS and Linux. 
 


### PR DESCRIPTION
**gitty** is a minimal single-binary CLI tool (Go) that wraps Git and GitHub into short, human-readable commands.

**Core value:** \`gitty up\` replaces the repetitive \`git add → commit → push\` cycle in one command.

Key commands:
- \`gitty up\` — stage all, auto-commit with smart message, push
- \`gitty fix <file>\` — interactive conflict resolution
- \`gitty erase <path>\` — remove path from all past commits
- \`gitty clone <repo>\` — clone + auto-setup

Available for: Linux (amd64/arm64), macOS, Windows — single binary, zero dependencies.

Repo: https://github.com/Omibranch/gitty

## Summary by Sourcery

New Features:
- Document the gitty CLI as an additional Git and GitHub helper tool in the Git section of the README.